### PR TITLE
Bump base upper bound for GHC 8.6

### DIFF
--- a/indexed-list-literals.cabal
+++ b/indexed-list-literals.cabal
@@ -59,7 +59,7 @@ library
   exposed-modules:     Data.IndexedListLiterals
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.9 && < 4.12
+  build-depends:       base >=4.9 && < 4.13
                      , Only >= 0.1 && < 0.2
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Hi! Thank you for the great library.

This is just a small PR to bump the upper bound on base to `< 4.13` (which builds with tests for me), making the library compatible with GHC 8.6 :)